### PR TITLE
docs: 📝 add DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,3 +18,4 @@ authors:
     given-names: Ann
   - family-names: Krevor
     given-names: Samuel
+doi: "10.5281/zenodo.15438165"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Repository: [github.com/ImperialCollegeLondon/StrataTrapper](https://github.com/
 ![GitHub Tag](https://img.shields.io/github/v/tag/ImperialCollegeLondon/StrataTrapper?sort=semver&style=flat&label=version)
 ![GitHub Release Date](https://img.shields.io/github/release-date/ImperialCollegeLondon/StrataTrapper?display_date=published_at&style=flat&label=dated)
 [![License](https://img.shields.io/badge/License-BSD_3--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
+[![DOI](https://zenodo.org/badge/741567808.svg)](https://doi.org/10.5281/zenodo.15438165)
 
 * [The StrataTrapper codes](#the-stratatrapper-codes)
 * [Structure](#structure)


### PR DESCRIPTION
Add DOI to citation and README

Includes the DOI for the project in the CITATION.cff file and adds a Zenodo DOI badge to the README for better referencing and visibility.