### PR TITLE
ci: remove Linkspector job from CI lints

### DIFF
--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -1,8 +1,6 @@
 on:
     workflow_call:
 jobs:
-    links:
-        uses: ./.github/workflows/links.yml
     commit:
         name: Commit messages
         runs-on: ubuntu-latest


### PR DESCRIPTION
Linkspector turned out to be extremely slow and unreliable.
