### PR TITLE
ci(matlab): skip MATLAB checks for draft PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
     pull_request:
         branches: [main]
+        types: [opened, synchronize, reopened, ready_for_review, converted_to_draft]
     push:
         branches: [main]
 concurrency:
@@ -14,6 +15,7 @@ jobs:
         name: Lints
         uses: ./.github/workflows/lints.yml
     matlab: # heavy MATLAB checks
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
         needs: lints
         uses: ./.github/workflows/matlab.yml
     webpage-build:


### PR DESCRIPTION
Refines CI pull request behavior:
- add pull_request types for opened, synchronize, reopened, and ready_for_review
- skip heavy MATLAB workflow while PR is in draft state